### PR TITLE
Refactor: replace deprecated QMouseEvent::globalPos() with globalPosition().toPoint()

### DIFF
--- a/ui/canvas/canvasview.cpp
+++ b/ui/canvas/canvasview.cpp
@@ -79,7 +79,7 @@ void CanvasView::middleMouseButtonPress(QMouseEvent *event) {
     auto releaseEvent = QMouseEvent(
         QEvent::MouseButtonRelease,
         event->pos(),
-        event->globalPos(),
+        event->globalPosition().toPoint(),
         Qt::LeftButton,
         Qt::NoButton,
         event->modifiers()
@@ -89,7 +89,7 @@ void CanvasView::middleMouseButtonPress(QMouseEvent *event) {
     auto fakeEvent = QMouseEvent(
         event->type(),
         event->pos(),
-        event->globalPos(),
+        event->globalPosition().toPoint(),
         Qt::LeftButton,
         event->buttons() | Qt::LeftButton,
         event->modifiers()
@@ -101,7 +101,7 @@ void CanvasView::middleMouseButtonRelease(QMouseEvent *event) {
     auto fakeEvent = QMouseEvent(
         event->type(),
         event->pos(),
-        event->globalPos(),
+        event->globalPosition().toPoint(),
         Qt::LeftButton,
         event->buttons() & Qt::LeftButton,
         event->modifiers()
@@ -292,7 +292,7 @@ void CanvasView::leftMouseButtonPress(QMouseEvent *event) {
             auto fake = QMouseEvent(
                 QEvent::MouseButtonRelease,
                 event->pos(),
-                event->globalPos(),
+                event->globalPosition().toPoint(),
                 Qt::LeftButton,
                 Qt::NoButton,
                 event->modifiers()


### PR DESCRIPTION
This PR updates the usage of QMouseEvent::globalPos() in canvasview.cpp to the recommended globalPosition().toPoint() API introduced in Qt6.

Why?

globalPos() is marked as deprecated in Qt6.

It internally calls globalPosition().toPoint(), which is the preferred method.

Updating ensures forward compatibility and removes compiler warnings.

Changes Made

Replaced all instances of event->globalPos() with event->globalPosition().toPoint().

Verified that functionality remains unchanged (coordinates still map to QPoint).

Impact

No functional changes.

Eliminates deprecation warnings during build.

Improves codebase compatibility with future Qt6+ versions.